### PR TITLE
Use libgtk-3-0 package instead of libgtk2.0-0

### DIFF
--- a/chromium/Dockerfile
+++ b/chromium/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:sid
 
 RUN apt-get update && \
-    apt-get -y install libglib2.0 libnss3-dev libxtst6 libxss1 libgconf-2-4 libfontconfig1 libpango1.0-0 libxcursor1 libxcomposite1 libasound2 libxdamage1 libxrandr2 libcups2 libgtk2.0-0 wget unzip libexif12 xvfb fonts-noto fonts-liberation && \
+    apt-get -y install libglib2.0 libnss3-dev libxtst6 libxss1 libgconf-2-4 libfontconfig1 libpango1.0-0 libxcursor1 libxcomposite1 libasound2 libxdamage1 libxrandr2 libcups2 libgtk-3-0 wget unzip libexif12 xvfb fonts-noto fonts-liberation && \
     rm -rf /var/lib/apt/lists/*
 
 RUN ln -s /lib/x86_64-linux-gnu/libudev.so.1 /lib/x86_64-linux-gnu/libudev.so.0


### PR DESCRIPTION
## Problem

The Docker image “quay.io/wakaba/chromedriver:chromium” currently doesn't work well.

> 33618.1.1.1: R: {"sessionId":"3741c4576532ce332e2e8ec952008bf3","status":13,"value":{"message":"unknown error: Chrome failed to start: exited abnormally\x5Cn  (Driver info: chromedriver=2.27.440175 (9bc1d90b8bfa4dd181fbbf769a5eb5e575574320),platform=Linux 3.13.0-106-generic x86_64)"}}

( https://circleci.com/gh/wakaba/docker-chromedriver/452 )

## Cause

As I executed `docker run --rm -it quay.io/wakaba/chromedriver:chromium bash` to launch bash on a container and then executed `google-chrome -v`, the following error was shown:

> \# google-chrome -v
> /chrome-linux/chrome: error while loading shared libraries: libgtk-3.so.0: cannot open shared object file: No such file or directory

It means the libgtk 3 library is needed.

## Change

I rewrite Dockerfile to install [libgtk-3-0](https://packages.debian.org/jessie/libgtk-3-0) package instead of [libgtk2.0-0](https://packages.debian.org/jessie/libgtk2.0-0).