### PR TITLE
Fix dependency problem: package libappindicator3-1

### DIFF
--- a/stable/Dockerfile
+++ b/stable/Dockerfile
@@ -4,7 +4,7 @@ ADD cd-bare /cd-bare
 
 RUN apt-get update && \
     apt-get -y install libglib2.0 libnss3-dev libxtst6 libxss1 libgconf-2-4 libfontconfig1 libpango1.0-0 libxcursor1 libxcomposite1 libasound2 libxdamage1 libxrandr2 libcups2 libgtk-3-0 wget unzip xvfb fonts-noto fonts-liberation libexif12 pulseaudio \
-        libappindicator1 libcurl3 xdg-utils lsb-release && \
+        libappindicator3-1 libcurl3 xdg-utils lsb-release && \
     wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
     dpkg -i google-chrome-stable_current_amd64.deb && \
     apt-get -f -y install && \


### PR DESCRIPTION
# Problem

* Although latest google-chrome-stable package depends on libappindicator3-1, current Dockerfile installs libappindicator1
* Build failed : https://circleci.com/gh/wakaba/docker-chromedriver/903

> Selecting previously unselected package google-chrome-stable.
(Reading database ... 30198 files and directories currently installed.)
Preparing to unpack google-chrome-stable_current_amd64.deb ...
Unpacking google-chrome-stable (66.0.3359.181-1) ...
dpkg: dependency problems prevent configuration of google-chrome-stable:
> google-chrome-stable depends on libappindicator3-1; however:
>  Package libappindicator3-1 is not installed.

# Fix

* Change libappindicator1 to libappindicator3-1
* Build passed : https://circleci.com/gh/nobuoka/docker-chromedriver/2